### PR TITLE
Batch custom scopes activation

### DIFF
--- a/core/deployment/src/main/java/io/quarkiverse/jberet/deployment/JBeretProcessor.java
+++ b/core/deployment/src/main/java/io/quarkiverse/jberet/deployment/JBeretProcessor.java
@@ -25,6 +25,9 @@ import java.util.stream.Stream;
 import jakarta.enterprise.inject.AmbiguousResolutionException;
 import jakarta.inject.Named;
 
+import org.jberet.cdi.JobScoped;
+import org.jberet.cdi.PartitionScoped;
+import org.jberet.cdi.StepScoped;
 import org.jberet.creation.ArchiveXmlLoader;
 import org.jberet.creation.BatchBeanProducer;
 import org.jberet.job.model.BatchArtifacts;
@@ -62,12 +65,17 @@ import io.quarkiverse.jberet.runtime.JBeretProducer;
 import io.quarkiverse.jberet.runtime.JBeretRecorder;
 import io.quarkiverse.jberet.runtime.JobsProducer;
 import io.quarkiverse.jberet.runtime.QuarkusJobScheduler;
+import io.quarkiverse.jberet.runtime.scope.QuarkusJobScopedContextImpl;
+import io.quarkiverse.jberet.runtime.scope.QuarkusPartitionScopedContextImpl;
+import io.quarkiverse.jberet.runtime.scope.QuarkusStepScopedContextImpl;
 import io.quarkus.agroal.spi.JdbcDataSourceBuildItem;
 import io.quarkus.arc.Unremovable;
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.arc.deployment.AnnotationsTransformerBuildItem;
 import io.quarkus.arc.deployment.BeanContainerBuildItem;
 import io.quarkus.arc.deployment.BeanDiscoveryFinishedBuildItem;
+import io.quarkus.arc.deployment.ContextRegistrationPhaseBuildItem;
+import io.quarkus.arc.deployment.ContextRegistrationPhaseBuildItem.ContextConfiguratorBuildItem;
 import io.quarkus.arc.deployment.ValidationPhaseBuildItem;
 import io.quarkus.arc.deployment.ValidationPhaseBuildItem.ValidationErrorBuildItem;
 import io.quarkus.arc.processor.AnnotationsTransformer;
@@ -110,6 +118,14 @@ public class JBeretProcessor {
     @BuildStep
     public RuntimeInitializedClassBuildItem runtimeInitializedDefaultHolder() {
         return new RuntimeInitializedClassBuildItem("org.jberet.spi.JobOperatorContext$DefaultHolder");
+    }
+
+    @BuildStep
+    public void batchScopes(ContextRegistrationPhaseBuildItem c, BuildProducer<ContextConfiguratorBuildItem> v) {
+        v.produce(new ContextConfiguratorBuildItem(
+                c.getContext().configure(JobScoped.class).contextClass(QuarkusJobScopedContextImpl.class),
+                c.getContext().configure(StepScoped.class).contextClass(QuarkusStepScopedContextImpl.class),
+                c.getContext().configure(PartitionScoped.class).contextClass(QuarkusPartitionScopedContextImpl.class)));
     }
 
     @BuildStep

--- a/core/runtime/src/main/java/io/quarkiverse/jberet/runtime/scope/QuarkusJobScopedContextImpl.java
+++ b/core/runtime/src/main/java/io/quarkiverse/jberet/runtime/scope/QuarkusJobScopedContextImpl.java
@@ -1,0 +1,54 @@
+package io.quarkiverse.jberet.runtime.scope;
+
+import java.lang.annotation.Annotation;
+
+import jakarta.enterprise.context.spi.Contextual;
+import jakarta.enterprise.context.spi.CreationalContext;
+
+import org.jberet.cdi.JobScoped;
+import org.jberet.creation.JobScopedContextImpl;
+
+import io.quarkus.arc.InjectableContext;
+
+public class QuarkusJobScopedContextImpl implements InjectableContext {
+    private final JobScopedContextImpl impl;
+
+    public QuarkusJobScopedContextImpl() {
+        this.impl = JobScopedContextImpl.getInstance();
+    }
+
+    @Override
+    public void destroy(Contextual<?> contextual) {
+        this.impl.destroy(contextual);
+    }
+
+    @Override
+    public Class<? extends Annotation> getScope() {
+        return JobScoped.class;
+    }
+
+    @Override
+    public <T> T get(Contextual<T> contextual, CreationalContext<T> creationalContext) {
+        return impl.get(contextual, creationalContext);
+    }
+
+    @Override
+    public <T> T get(Contextual<T> contextual) {
+        return impl.get(contextual);
+    }
+
+    @Override
+    public boolean isActive() {
+        return impl.isActive();
+    }
+
+    @Override
+    public void destroy() {
+        this.impl.destroy(null);
+    }
+
+    @Override
+    public ContextState getState() {
+        return null;
+    }
+}

--- a/core/runtime/src/main/java/io/quarkiverse/jberet/runtime/scope/QuarkusPartitionScopedContextImpl.java
+++ b/core/runtime/src/main/java/io/quarkiverse/jberet/runtime/scope/QuarkusPartitionScopedContextImpl.java
@@ -1,0 +1,54 @@
+package io.quarkiverse.jberet.runtime.scope;
+
+import java.lang.annotation.Annotation;
+
+import jakarta.enterprise.context.spi.Contextual;
+import jakarta.enterprise.context.spi.CreationalContext;
+
+import org.jberet.cdi.PartitionScoped;
+import org.jberet.creation.PartitionScopedContextImpl;
+
+import io.quarkus.arc.InjectableContext;
+
+public class QuarkusPartitionScopedContextImpl implements InjectableContext {
+    private final PartitionScopedContextImpl impl;
+
+    public QuarkusPartitionScopedContextImpl() {
+        this.impl = PartitionScopedContextImpl.getInstance();
+    }
+
+    @Override
+    public void destroy(Contextual<?> contextual) {
+        this.impl.destroy(contextual);
+    }
+
+    @Override
+    public Class<? extends Annotation> getScope() {
+        return PartitionScoped.class;
+    }
+
+    @Override
+    public <T> T get(Contextual<T> contextual, CreationalContext<T> creationalContext) {
+        return impl.get(contextual, creationalContext);
+    }
+
+    @Override
+    public <T> T get(Contextual<T> contextual) {
+        return impl.get(contextual);
+    }
+
+    @Override
+    public boolean isActive() {
+        return impl.isActive();
+    }
+
+    @Override
+    public void destroy() {
+        this.impl.destroy(null);
+    }
+
+    @Override
+    public ContextState getState() {
+        return null;
+    }
+}

--- a/core/runtime/src/main/java/io/quarkiverse/jberet/runtime/scope/QuarkusStepScopedContextImpl.java
+++ b/core/runtime/src/main/java/io/quarkiverse/jberet/runtime/scope/QuarkusStepScopedContextImpl.java
@@ -1,0 +1,54 @@
+package io.quarkiverse.jberet.runtime.scope;
+
+import java.lang.annotation.Annotation;
+
+import jakarta.enterprise.context.spi.Contextual;
+import jakarta.enterprise.context.spi.CreationalContext;
+
+import org.jberet.cdi.StepScoped;
+import org.jberet.creation.StepScopedContextImpl;
+
+import io.quarkus.arc.InjectableContext;
+
+public class QuarkusStepScopedContextImpl implements InjectableContext {
+    private final StepScopedContextImpl impl;
+
+    public QuarkusStepScopedContextImpl() {
+        this.impl = StepScopedContextImpl.getInstance();
+    }
+
+    @Override
+    public void destroy(Contextual<?> contextual) {
+        this.impl.destroy(contextual);
+    }
+
+    @Override
+    public Class<? extends Annotation> getScope() {
+        return StepScoped.class;
+    }
+
+    @Override
+    public <T> T get(Contextual<T> contextual, CreationalContext<T> creationalContext) {
+        return impl.get(contextual, creationalContext);
+    }
+
+    @Override
+    public <T> T get(Contextual<T> contextual) {
+        return impl.get(contextual);
+    }
+
+    @Override
+    public boolean isActive() {
+        return impl.isActive();
+    }
+
+    @Override
+    public void destroy() {
+        this.impl.destroy(null);
+    }
+
+    @Override
+    public ContextState getState() {
+        return null;
+    }
+}

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -77,6 +77,7 @@
     <module>programmatic</module>
     <module>client</module>
     <module>scripting</module>
+    <module>scopes</module>
     <module>tck</module>
   </modules>
 

--- a/integration-tests/scopes/common/pom.xml
+++ b/integration-tests/scopes/common/pom.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+    	<groupId>io.quarkiverse.jberet</groupId>
+    	<artifactId>quarkus-jberet-integration-tests</artifactId>
+    	<version>2.2.1-SNAPSHOT</version>
+    	<relativePath>../..</relativePath>
+  	</parent>
+  	
+    <artifactId>quarkus-jberet-integration-tests-scopes-commons</artifactId>
+    <name>Quarkus - JBeret - Integrations Tests - Scopes - Common</name>
+
+	<dependencies>
+		<dependency>
+    		<groupId>io.quarkus</groupId>
+      		<artifactId>quarkus-junit5</artifactId>  		
+    	</dependency>
+    	<dependency>
+			<groupId>org.jberet.test-apps</groupId>
+	        <version>${jberet.version}</version>
+    		<artifactId>cdiScopes-commons</artifactId>
+    		<exclusions>
+				<exclusion>
+					<groupId>junit</groupId>
+					<artifactId>junit</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+	</dependencies>
+</project>

--- a/integration-tests/scopes/common/src/main/java/io/quarkiverse/jberet/it/cdiscopes/AbstractQuarkusIT.java
+++ b/integration-tests/scopes/common/src/main/java/io/quarkiverse/jberet/it/cdiscopes/AbstractQuarkusIT.java
@@ -1,0 +1,22 @@
+package io.quarkiverse.jberet.it.cdiscopes;
+
+import jakarta.inject.Inject;
+
+import org.jberet.testapps.common.AbstractIT;
+import org.junit.jupiter.api.BeforeEach;
+
+import io.quarkiverse.jberet.runtime.QuarkusJobOperator;
+
+/**
+ * Quarkus version of JBeret {@link AbstractIT}
+ */
+public abstract class AbstractQuarkusIT extends AbstractIT {
+    @Inject
+    QuarkusJobOperator quarkusJobOperator;
+
+    @BeforeEach
+    @Override
+    public void before() throws Exception {
+        super.jobOperator = new JobOperatorImplQuarkusDelegate(quarkusJobOperator);
+    }
+}

--- a/integration-tests/scopes/common/src/main/java/io/quarkiverse/jberet/it/cdiscopes/JobOperatorImplQuarkusDelegate.java
+++ b/integration-tests/scopes/common/src/main/java/io/quarkiverse/jberet/it/cdiscopes/JobOperatorImplQuarkusDelegate.java
@@ -1,0 +1,165 @@
+package io.quarkiverse.jberet.it.cdiscopes;
+
+import java.util.List;
+import java.util.Properties;
+import java.util.Set;
+
+import jakarta.batch.operations.JobExecutionAlreadyCompleteException;
+import jakarta.batch.operations.JobExecutionIsRunningException;
+import jakarta.batch.operations.JobExecutionNotMostRecentException;
+import jakarta.batch.operations.JobExecutionNotRunningException;
+import jakarta.batch.operations.JobRestartException;
+import jakarta.batch.operations.JobSecurityException;
+import jakarta.batch.operations.JobStartException;
+import jakarta.batch.operations.NoSuchJobException;
+import jakarta.batch.operations.NoSuchJobExecutionException;
+import jakarta.batch.operations.NoSuchJobInstanceException;
+import jakarta.batch.runtime.JobExecution;
+import jakarta.batch.runtime.JobInstance;
+import jakarta.batch.runtime.StepExecution;
+
+import org.jberet.job.model.Job;
+import org.jberet.operations.JobOperatorImpl;
+import org.jberet.repository.JobRepository;
+import org.jberet.spi.BatchEnvironment;
+import org.jberet.testapps.common.AbstractIT;
+
+import io.quarkiverse.jberet.runtime.QuarkusJobOperator;
+
+/**
+ * Used in {@link AbstractQuarkusIT} to set {@link AbstractIT} jobOperator field
+ * because it is declared as {@link JobOperatorImpl}
+ */
+public class JobOperatorImplQuarkusDelegate extends JobOperatorImpl {
+    private final QuarkusJobOperator delegate;
+
+    public JobOperatorImplQuarkusDelegate(QuarkusJobOperator delegate) {
+        super(delegate.getBatchEnvironment());
+        this.delegate = delegate;
+    }
+
+    /**
+     * String .xml extension from XML job name
+     *
+     * @param jobXMLName
+     * @return
+     */
+    private String jobXMLNameToJobName(String jobXMLName) {
+        if (jobXMLName.endsWith(".xml")) {
+            jobXMLName = jobXMLName.substring(0, jobXMLName.length() - 4);
+        }
+        return jobXMLName;
+    }
+
+    @Override
+    public long start(String jobXMLName, Properties jobParameters) throws JobStartException, JobSecurityException {
+        jobXMLName = jobXMLNameToJobName(jobXMLName);
+        return delegate.start(jobXMLName, jobParameters);
+    }
+
+    @Override
+    public long start(String jobXMLName, Properties jobParameters, String user)
+            throws JobStartException, JobSecurityException {
+        jobXMLName = jobXMLNameToJobName(jobXMLName);
+        return delegate.start(jobXMLName, jobParameters, user);
+    }
+
+    @Override
+    public JobRepository getJobRepository() {
+        return delegate.getJobRepository();
+    }
+
+    @Override
+    public long restart(long executionId, Properties restartParameters) throws JobExecutionAlreadyCompleteException,
+            NoSuchJobExecutionException, JobExecutionNotMostRecentException, JobRestartException, JobSecurityException {
+        return delegate.restart(executionId, restartParameters);
+    }
+
+    @Override
+    public long restart(long executionId, Properties restartParameters, String user)
+            throws JobExecutionAlreadyCompleteException, NoSuchJobExecutionException,
+            JobExecutionNotMostRecentException, JobRestartException, JobSecurityException {
+        return delegate.restart(executionId, restartParameters, user);
+    }
+
+    @Override
+    public long start(Job jobDefined, Properties jobParameters) throws JobStartException, JobSecurityException {
+        return delegate.start(jobDefined, jobParameters);
+    }
+
+    @Override
+    public BatchEnvironment getBatchEnvironment() {
+        return delegate.getBatchEnvironment();
+    }
+
+    @Override
+    public long start(Job jobDefined, Properties jobParameters, String user)
+            throws JobStartException, JobSecurityException {
+        return delegate.start(jobDefined, jobParameters, user);
+    }
+
+    @Override
+    public void stop(long executionId)
+            throws NoSuchJobExecutionException, JobExecutionNotRunningException, JobSecurityException {
+        delegate.stop(executionId);
+    }
+
+    @Override
+    public Set<String> getJobNames() throws JobSecurityException {
+        return delegate.getJobNames();
+    }
+
+    @Override
+    public int getJobInstanceCount(String jobName) throws NoSuchJobException, JobSecurityException {
+        return delegate.getJobInstanceCount(jobName);
+    }
+
+    @Override
+    public List<JobInstance> getJobInstances(String jobName, int start, int count)
+            throws NoSuchJobException, JobSecurityException {
+        return delegate.getJobInstances(jobName, start, count);
+    }
+
+    @Override
+    public List<Long> getRunningExecutions(String jobName) throws NoSuchJobException, JobSecurityException {
+        return delegate.getRunningExecutions(jobName);
+    }
+
+    @Override
+    public Properties getParameters(long executionId) throws NoSuchJobExecutionException, JobSecurityException {
+        return delegate.getParameters(executionId);
+    }
+
+    @Override
+    public void abandon(long executionId)
+            throws NoSuchJobExecutionException, JobExecutionIsRunningException, JobSecurityException {
+        delegate.abandon(executionId);
+    }
+
+    @Override
+    public JobInstance getJobInstance(long executionId) throws NoSuchJobExecutionException, JobSecurityException {
+        return delegate.getJobInstance(executionId);
+    }
+
+    @Override
+    public List<JobExecution> getJobExecutions(JobInstance instance)
+            throws NoSuchJobInstanceException, JobSecurityException {
+        return delegate.getJobExecutions(instance);
+    }
+
+    @Override
+    public List<Long> getJobExecutionsByJob(String jobName) {
+        return delegate.getJobExecutionsByJob(jobName);
+    }
+
+    @Override
+    public JobExecution getJobExecution(long executionId) throws NoSuchJobExecutionException, JobSecurityException {
+        return delegate.getJobExecution(executionId);
+    }
+
+    @Override
+    public List<StepExecution> getStepExecutions(long jobExecutionId)
+            throws NoSuchJobExecutionException, JobSecurityException {
+        return delegate.getStepExecutions(jobExecutionId);
+    }
+}

--- a/integration-tests/scopes/job-scoped/pom.xml
+++ b/integration-tests/scopes/job-scoped/pom.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+    	<groupId>io.quarkiverse.jberet</groupId>
+    	<artifactId>quarkus-jberet-integration-tests</artifactId>
+    	<version>2.2.1-SNAPSHOT</version>
+    	<relativePath>../..</relativePath>
+  	</parent>
+
+    <artifactId>quarkus-jberet-integration-tests-scopes-jobscopes</artifactId>
+    <name>Quarkus - JBeret - Integrations Tests - Scopes - Job</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkiverse.jberet</groupId>
+            <artifactId>quarkus-jberet-integration-tests-scopes-commons</artifactId>
+            <version>2.2.1-SNAPSHOT</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+			<groupId>org.jberet.test-apps</groupId>
+        	<version>${jberet.version}</version>
+		    <artifactId>jobScoped</artifactId>
+		    <scope>test</scope>
+		</dependency>
+    </dependencies>
+    <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <skipTests>${native.surefire.skip}</skipTests>
+            </configuration>
+          </plugin>
+          <plugin>
+            <artifactId>maven-failsafe-plugin</artifactId>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>integration-test</goal>
+                  <goal>verify</goal>
+                </goals>
+                <configuration>
+                  <systemPropertyVariables>
+                    <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
+                  </systemPropertyVariables>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+    </build>
+</project>

--- a/integration-tests/scopes/job-scoped/src/main/resources/application.properties
+++ b/integration-tests/scopes/job-scoped/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+quarkus.jberet.jobs.excludes=partition-segment.xml

--- a/integration-tests/scopes/job-scoped/src/test/java/io/quarkiverse/jberet/it/scopes/jobscoped/JobScopeBatchlet1.java
+++ b/integration-tests/scopes/job-scoped/src/test/java/io/quarkiverse/jberet/it/scopes/jobscoped/JobScopeBatchlet1.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2015-2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package io.quarkiverse.jberet.it.scopes.jobscoped;
+
+import jakarta.annotation.Priority;
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.inject.Alternative;
+import jakarta.enterprise.inject.Typed;
+import jakarta.inject.Named;
+
+@Named
+@Dependent
+@Alternative
+@Priority(1)
+@Typed(value = org.jberet.testapps.cdiscopes.jobscoped.JobScopeBatchlet1.class)
+public class JobScopeBatchlet1 extends org.jberet.testapps.cdiscopes.jobscoped.JobScopeBatchlet1 {
+}

--- a/integration-tests/scopes/job-scoped/src/test/java/io/quarkiverse/jberet/it/scopes/jobscoped/JobScopeBatchlet2.java
+++ b/integration-tests/scopes/job-scoped/src/test/java/io/quarkiverse/jberet/it/scopes/jobscoped/JobScopeBatchlet2.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2015-2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package io.quarkiverse.jberet.it.scopes.jobscoped;
+
+import jakarta.annotation.Priority;
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.inject.Alternative;
+import jakarta.enterprise.inject.Typed;
+import jakarta.inject.Named;
+
+@Named
+@Dependent
+@Alternative
+@Priority(1)
+@Typed(value = org.jberet.testapps.cdiscopes.jobscoped.JobScopeBatchlet2.class)
+public class JobScopeBatchlet2 extends org.jberet.testapps.cdiscopes.jobscoped.JobScopeBatchlet2 {
+}

--- a/integration-tests/scopes/job-scoped/src/test/java/io/quarkiverse/jberet/it/scopes/jobscoped/JobScopePartitionAnalyzer.java
+++ b/integration-tests/scopes/job-scoped/src/test/java/io/quarkiverse/jberet/it/scopes/jobscoped/JobScopePartitionAnalyzer.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package io.quarkiverse.jberet.it.scopes.jobscoped;
+
+import jakarta.annotation.Priority;
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.inject.Alternative;
+import jakarta.enterprise.inject.Typed;
+import jakarta.inject.Named;
+
+@Named
+@Dependent
+@Alternative
+@Priority(1)
+@Typed(value = org.jberet.testapps.cdiscopes.jobscoped.JobScopePartitionAnalyzer.class)
+public class JobScopePartitionAnalyzer extends org.jberet.testapps.cdiscopes.jobscoped.JobScopePartitionAnalyzer {
+}

--- a/integration-tests/scopes/job-scoped/src/test/java/io/quarkiverse/jberet/it/scopes/jobscoped/JobScopedIT.java
+++ b/integration-tests/scopes/job-scoped/src/test/java/io/quarkiverse/jberet/it/scopes/jobscoped/JobScopedIT.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package io.quarkiverse.jberet.it.scopes.jobscoped;
+
+import jakarta.batch.runtime.BatchStatus;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import io.quarkiverse.jberet.it.cdiscopes.AbstractQuarkusIT;
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+class JobScopedIT extends AbstractQuarkusIT {
+    private static final String jobScopedTest = "jobScoped";
+    private static final String jobScopedTest2 = "jobScoped2";
+    private static final String jobScopedPartitionedTest = "jobScopedPartitioned";
+    private static final String jobScopedPartitionedTest2 = "jobScoped2Partitioned";
+
+    @Test
+    void jobScopedTest() throws Exception {
+        startJobAndWait(jobScopedTest);
+        Assertions.assertEquals(BatchStatus.COMPLETED, jobExecution.getBatchStatus());
+        Assertions.assertEquals("jobScoped.step1TYPE jobScoped.step1METHOD jobScoped.step1FIELD",
+                stepExecutions.get(0).getExitStatus());
+        Assertions.assertEquals(
+                "jobScoped.step1TYPE jobScoped.step2TYPE jobScoped.step1METHOD jobScoped.step2METHOD jobScoped.step1FIELD jobScoped.step2FIELD",
+                stepExecutions.get(1).getExitStatus());
+
+        stepExecutions.clear();
+        jobExecution = null;
+        stepExecutions = null;
+
+        // run jobScoped2 to check that a different Foo instance is used within the
+        // scope of jobScoped2
+        startJobAndWait(jobScopedTest2);
+        Assertions.assertEquals(BatchStatus.COMPLETED, jobExecution.getBatchStatus());
+        Assertions.assertEquals("jobScoped2.step1TYPE jobScoped2.step1METHOD jobScoped2.step1FIELD",
+                stepExecutions.get(0).getExitStatus());
+        Assertions.assertEquals(
+                "jobScoped2.step1TYPE jobScoped2.step2TYPE jobScoped2.step1METHOD jobScoped2.step2METHOD jobScoped2.step1FIELD jobScoped2.step2FIELD",
+                stepExecutions.get(1).getExitStatus());
+    }
+
+    @Test
+    void jobScopedPartitionedTest() throws Exception {
+        startJobAndWait(jobScopedPartitionedTest);
+        Assertions.assertEquals(BatchStatus.COMPLETED, jobExecution.getBatchStatus());
+
+        // step2 exit status is set in analyzer, to foo.stepNames, which should include
+        // values from both step1 and 2.
+        String step2ExitStatus = stepExecutions.get(1).getExitStatus();
+        Assertions.assertEquals(
+                "jobScopedPartitioned.step1TYPE jobScopedPartitioned.step1TYPE jobScopedPartitioned.step2TYPE jobScopedPartitioned.step2TYPE jobScopedPartitioned.step1METHOD jobScopedPartitioned.step1METHOD jobScopedPartitioned.step2METHOD jobScopedPartitioned.step2METHOD jobScopedPartitioned.step1FIELD jobScopedPartitioned.step1FIELD jobScopedPartitioned.step2FIELD jobScopedPartitioned.step2FIELD",
+                step2ExitStatus);
+
+        stepExecutions.clear();
+        jobExecution = null;
+        stepExecutions = null;
+        step2ExitStatus = null;
+
+        // run jobScoped2 to check that a different Foo instance is used within the
+        // scope of jobScoped2
+        startJobAndWait(jobScopedPartitionedTest2);
+        Assertions.assertEquals(BatchStatus.COMPLETED, jobExecution.getBatchStatus());
+        step2ExitStatus = stepExecutions.get(1).getExitStatus();
+        Assertions.assertEquals(
+                "jobScoped2Partitioned.step1TYPE jobScoped2Partitioned.step1TYPE jobScoped2Partitioned.step2TYPE jobScoped2Partitioned.step2TYPE jobScoped2Partitioned.step1METHOD jobScoped2Partitioned.step1METHOD jobScoped2Partitioned.step2METHOD jobScoped2Partitioned.step2METHOD jobScoped2Partitioned.step1FIELD jobScoped2Partitioned.step1FIELD jobScoped2Partitioned.step2FIELD jobScoped2Partitioned.step2FIELD",
+                step2ExitStatus);
+    }
+}

--- a/integration-tests/scopes/partition-scoped/pom.xml
+++ b/integration-tests/scopes/partition-scoped/pom.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+    	<groupId>io.quarkiverse.jberet</groupId>
+    	<artifactId>quarkus-jberet-integration-tests</artifactId>
+    	<version>2.2.1-SNAPSHOT</version>
+    	<relativePath>../..</relativePath>
+  	</parent>
+
+    <artifactId>quarkus-jberet-integration-tests-scopes-partitionscoped</artifactId>
+    <name>Quarkus - JBeret - Integrations Tests - Scopes - Partition</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkiverse.jberet</groupId>
+            <artifactId>quarkus-jberet-integration-tests-scopes-commons</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+			<groupId>org.jberet.test-apps</groupId>
+        	<version>${jberet.version}</version>
+		    <artifactId>partitionScoped</artifactId>
+		    <scope>test</scope>
+		</dependency>
+    </dependencies>
+    <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <skipTests>${native.surefire.skip}</skipTests>
+            </configuration>
+          </plugin>
+          <plugin>
+            <artifactId>maven-failsafe-plugin</artifactId>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>integration-test</goal>
+                  <goal>verify</goal>
+                </goals>
+                <configuration>
+                  <systemPropertyVariables>
+                    <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
+                  </systemPropertyVariables>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+    </build>
+</project>

--- a/integration-tests/scopes/partition-scoped/src/test/java/io/quarkiverse/jberet/it/scopes/partitionscoped/PartitionScopeBatchlet1.java
+++ b/integration-tests/scopes/partition-scoped/src/test/java/io/quarkiverse/jberet/it/scopes/partitionscoped/PartitionScopeBatchlet1.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2015-2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package io.quarkiverse.jberet.it.scopes.partitionscoped;
+
+import jakarta.annotation.Priority;
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.inject.Alternative;
+import jakarta.enterprise.inject.Typed;
+import jakarta.inject.Named;
+
+@Named
+@Dependent
+@Alternative
+@Priority(1)
+@Typed(org.jberet.testapps.cdiscopes.partitionscoped.PartitionScopeBatchlet1.class)
+public class PartitionScopeBatchlet1 extends org.jberet.testapps.cdiscopes.partitionscoped.PartitionScopeBatchlet1 {
+}

--- a/integration-tests/scopes/partition-scoped/src/test/java/io/quarkiverse/jberet/it/scopes/partitionscoped/PartitionScopeJobListener.java
+++ b/integration-tests/scopes/partition-scoped/src/test/java/io/quarkiverse/jberet/it/scopes/partitionscoped/PartitionScopeJobListener.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package io.quarkiverse.jberet.it.scopes.partitionscoped;
+
+import jakarta.annotation.Priority;
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.inject.Alternative;
+import jakarta.enterprise.inject.Typed;
+import jakarta.inject.Named;
+
+@Named
+@Dependent
+@Alternative
+@Priority(1)
+@Typed(org.jberet.testapps.cdiscopes.partitionscoped.PartitionScopeJobListener.class)
+public class PartitionScopeJobListener extends org.jberet.testapps.cdiscopes.partitionscoped.PartitionScopeJobListener {
+}

--- a/integration-tests/scopes/partition-scoped/src/test/java/io/quarkiverse/jberet/it/scopes/partitionscoped/PartitionScopePartitionAnalyzer.java
+++ b/integration-tests/scopes/partition-scoped/src/test/java/io/quarkiverse/jberet/it/scopes/partitionscoped/PartitionScopePartitionAnalyzer.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package io.quarkiverse.jberet.it.scopes.partitionscoped;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.UndeclaredThrowableException;
+import java.util.Set;
+
+import jakarta.annotation.Priority;
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.inject.Alternative;
+import jakarta.enterprise.inject.Typed;
+import jakarta.inject.Named;
+
+@Named
+@Dependent
+@Alternative
+@Priority(1)
+@Typed(org.jberet.testapps.cdiscopes.partitionscoped.PartitionScopePartitionAnalyzer.class)
+public class PartitionScopePartitionAnalyzer
+        extends org.jberet.testapps.cdiscopes.partitionscoped.PartitionScopePartitionAnalyzer {
+    static public Set<String> getExpectedData() {
+        try {
+            Field f = org.jberet.testapps.cdiscopes.partitionscoped.PartitionScopePartitionAnalyzer.class
+                    .getDeclaredField("expectedData");
+            f.setAccessible(true);
+            return (Set<String>) f.get(null);
+        } catch (ReflectiveOperationException | SecurityException e) {
+            throw new UndeclaredThrowableException(e.getCause());
+        }
+    }
+}

--- a/integration-tests/scopes/partition-scoped/src/test/java/io/quarkiverse/jberet/it/scopes/partitionscoped/PartitionScopePartitionCollector.java
+++ b/integration-tests/scopes/partition-scoped/src/test/java/io/quarkiverse/jberet/it/scopes/partitionscoped/PartitionScopePartitionCollector.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2015-2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package io.quarkiverse.jberet.it.scopes.partitionscoped;
+
+import jakarta.annotation.Priority;
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.inject.Alternative;
+import jakarta.enterprise.inject.Typed;
+import jakarta.inject.Named;
+
+@Named
+@Dependent
+@Alternative
+@Priority(1)
+@Typed(org.jberet.testapps.cdiscopes.partitionscoped.PartitionScopePartitionCollector.class)
+public class PartitionScopePartitionCollector
+        extends org.jberet.testapps.cdiscopes.partitionscoped.PartitionScopePartitionCollector {
+}

--- a/integration-tests/scopes/partition-scoped/src/test/java/io/quarkiverse/jberet/it/scopes/partitionscoped/PartitionScopeStepListener.java
+++ b/integration-tests/scopes/partition-scoped/src/test/java/io/quarkiverse/jberet/it/scopes/partitionscoped/PartitionScopeStepListener.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package io.quarkiverse.jberet.it.scopes.partitionscoped;
+
+import jakarta.annotation.Priority;
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.inject.Alternative;
+import jakarta.enterprise.inject.Typed;
+import jakarta.inject.Named;
+
+@Named
+@Dependent
+@Alternative
+@Priority(1)
+@Typed(org.jberet.testapps.cdiscopes.partitionscoped.PartitionScopeStepListener.class)
+public class PartitionScopeStepListener extends org.jberet.testapps.cdiscopes.partitionscoped.PartitionScopeStepListener {
+}

--- a/integration-tests/scopes/partition-scoped/src/test/java/io/quarkiverse/jberet/it/scopes/partitionscoped/PartitionScopedIT.java
+++ b/integration-tests/scopes/partition-scoped/src/test/java/io/quarkiverse/jberet/it/scopes/partitionscoped/PartitionScopedIT.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package io.quarkiverse.jberet.it.scopes.partitionscoped;
+
+import jakarta.batch.runtime.BatchStatus;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import io.quarkiverse.jberet.it.cdiscopes.AbstractQuarkusIT;
+import io.quarkus.test.junit.QuarkusTest;
+
+/**
+ * Tests for {@link org.jberet.cdi.PartitionScoped}.
+ */
+@QuarkusTest
+class PartitionScopedIT extends AbstractQuarkusIT {
+    static final String partitionScopedTest = "partitionScopedPartitioned";
+    static final String partitionScopedFailJobListenerTest = "partitionScopedFailJobListener";
+    static final String partitionScopedFailStepListenerTest = "partitionScopedFailStepListener";
+
+    @Test
+    void partitionScopedTest() throws Exception {
+        // same partition, different artifacts, injected Foo should be different
+        // different partition, injected Foo should be the different
+
+        startJobAndWait(partitionScopedTest);
+        Assertions.assertEquals(BatchStatus.COMPLETED, jobExecution.getBatchStatus());
+        final String exitStatus = stepExecution0.getExitStatus();
+        System.out.printf("step exit status: %s%n", exitStatus);
+        // There's not guarantee which orders threads will be processed in, just check
+        // the existStatus contains
+        // each value from the expected data.
+        for (String expected : PartitionScopePartitionAnalyzer.getExpectedData()) {
+            Assertions.assertTrue(exitStatus.contains(expected),
+                    "Missing expected data '" + expected + "' in '" + exitStatus + "'");
+        }
+    }
+
+    @Test
+    void partitionScopedFailJobListener() throws Exception {
+        // injecting @PartitionScoped Foo into a job listener will fail
+        startJobAndWait(partitionScopedFailJobListenerTest);
+        Assertions.assertEquals(BatchStatus.FAILED, jobExecution.getBatchStatus());
+    }
+
+    @Test
+    void partitionScopedFailStepListener() throws Exception {
+        // injecting @PartitionScoped Foo into a step listener will fail
+        startJobAndWait(partitionScopedFailStepListenerTest);
+        Assertions.assertEquals(BatchStatus.FAILED, jobExecution.getBatchStatus());
+    }
+
+}

--- a/integration-tests/scopes/pom.xml
+++ b/integration-tests/scopes/pom.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <packaging>pom</packaging>
+    <modules>
+        <module>common</module>
+        <module>job-scoped</module>
+        <module>step-scoped</module>
+        <module>partition-scoped</module>
+    </modules>
+
+    <parent>
+    	<groupId>io.quarkiverse.jberet</groupId>
+    	<artifactId>quarkus-jberet-integration-tests</artifactId>
+        <version>2.2.1-SNAPSHOT</version>
+        <relativePath>..</relativePath>
+    </parent>
+
+    <artifactId>quarkus-jberet-integration-tests-scopes</artifactId>
+    <name>Quarkus - JBeret - Integrations Tests - Scopes</name>
+
+</project>

--- a/integration-tests/scopes/step-scoped/pom.xml
+++ b/integration-tests/scopes/step-scoped/pom.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+    	<groupId>io.quarkiverse.jberet</groupId>
+    	<artifactId>quarkus-jberet-integration-tests</artifactId>
+    	<version>2.2.1-SNAPSHOT</version>
+    	<relativePath>../..</relativePath>
+  	</parent>
+
+    <artifactId>quarkus-jberet-integration-tests-scopes-stepscoped</artifactId>
+    <name>Quarkus - JBeret - Integrations Tests - Scopes - Step</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkiverse.jberet</groupId>
+            <artifactId>quarkus-jberet-integration-tests-scopes-commons</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+			<groupId>org.jberet.test-apps</groupId>
+        	<version>${jberet.version}</version>
+		    <artifactId>stepScoped</artifactId>
+		    <scope>test</scope>
+		</dependency>
+    </dependencies>
+    <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <skipTests>${native.surefire.skip}</skipTests>
+            </configuration>
+          </plugin>
+          <plugin>
+            <artifactId>maven-failsafe-plugin</artifactId>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>integration-test</goal>
+                  <goal>verify</goal>
+                </goals>
+                <configuration>
+                  <systemPropertyVariables>
+                    <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
+                  </systemPropertyVariables>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+    </build>
+</project>

--- a/integration-tests/scopes/step-scoped/src/test/java/io/quarkiverse/jberet/it/scopes/stepscoped/StepScopeBatchlet1.java
+++ b/integration-tests/scopes/step-scoped/src/test/java/io/quarkiverse/jberet/it/scopes/stepscoped/StepScopeBatchlet1.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2015-2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package io.quarkiverse.jberet.it.scopes.stepscoped;
+
+import jakarta.annotation.Priority;
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.inject.Alternative;
+import jakarta.enterprise.inject.Typed;
+import jakarta.inject.Named;
+
+@Named
+@Dependent
+@Alternative
+@Priority(1)
+@Typed(org.jberet.testapps.cdiscopes.stepscoped.StepScopeBatchlet1.class)
+public class StepScopeBatchlet1 extends org.jberet.testapps.cdiscopes.stepscoped.StepScopeBatchlet1 {
+}

--- a/integration-tests/scopes/step-scoped/src/test/java/io/quarkiverse/jberet/it/scopes/stepscoped/StepScopeBatchlet2.java
+++ b/integration-tests/scopes/step-scoped/src/test/java/io/quarkiverse/jberet/it/scopes/stepscoped/StepScopeBatchlet2.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2015-2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package io.quarkiverse.jberet.it.scopes.stepscoped;
+
+import jakarta.annotation.Priority;
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.inject.Alternative;
+import jakarta.enterprise.inject.Typed;
+import jakarta.inject.Named;
+
+@Named
+@Dependent
+@Alternative
+@Priority(1)
+@Typed(org.jberet.testapps.cdiscopes.stepscoped.StepScopeBatchlet2.class)
+public class StepScopeBatchlet2 extends org.jberet.testapps.cdiscopes.stepscoped.StepScopeBatchlet2 {
+}

--- a/integration-tests/scopes/step-scoped/src/test/java/io/quarkiverse/jberet/it/scopes/stepscoped/StepScopeJobListener.java
+++ b/integration-tests/scopes/step-scoped/src/test/java/io/quarkiverse/jberet/it/scopes/stepscoped/StepScopeJobListener.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package io.quarkiverse.jberet.it.scopes.stepscoped;
+
+import jakarta.annotation.Priority;
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.inject.Alternative;
+import jakarta.enterprise.inject.Typed;
+import jakarta.inject.Named;
+
+@Named
+@Dependent
+@Alternative
+@Priority(1)
+@Typed(org.jberet.testapps.cdiscopes.stepscoped.StepScopeJobListener.class)
+public class StepScopeJobListener extends org.jberet.testapps.cdiscopes.stepscoped.StepScopeJobListener {
+}

--- a/integration-tests/scopes/step-scoped/src/test/java/io/quarkiverse/jberet/it/scopes/stepscoped/StepScopePartitionAnalyzer.java
+++ b/integration-tests/scopes/step-scoped/src/test/java/io/quarkiverse/jberet/it/scopes/stepscoped/StepScopePartitionAnalyzer.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2015-2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package io.quarkiverse.jberet.it.scopes.stepscoped;
+
+import java.util.List;
+
+import jakarta.annotation.Priority;
+import jakarta.batch.runtime.BatchStatus;
+import jakarta.batch.runtime.context.StepContext;
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.inject.Alternative;
+import jakarta.enterprise.inject.Typed;
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
+
+import org.jberet.testapps.cdiscopes.stepscoped.Foo;
+
+@Named
+@Dependent
+@Alternative
+@Priority(1)
+@Typed(org.jberet.testapps.cdiscopes.stepscoped.StepScopePartitionAnalyzer.class)
+public class StepScopePartitionAnalyzer extends org.jberet.testapps.cdiscopes.stepscoped.StepScopePartitionAnalyzer {
+    @Inject
+    private Foo foo;
+
+    @Inject
+    private StepContext stepContext;
+
+    static final int numberOfPartitions = 3;
+    private int numberOfPartitionsFinished;
+
+    @Override
+    public void analyzeStatus(final BatchStatus batchStatus, final String exitStatus) throws Exception {
+        if (++numberOfPartitionsFinished == numberOfPartitions) {
+            final List<String> stepNames = foo.getStepNames();
+
+            // 3 entries from 3 partitions, plus step listener before step (after step not
+            // executed yet)
+            if (stepNames.size() == 4) {
+                stepContext.setExitStatus(stepNames.toString());
+            } else {
+                throw new IllegalStateException("Expecting 4 elements, but got " + stepNames);
+            }
+        }
+    }
+}

--- a/integration-tests/scopes/step-scoped/src/test/java/io/quarkiverse/jberet/it/scopes/stepscoped/StepScopedIT.java
+++ b/integration-tests/scopes/step-scoped/src/test/java/io/quarkiverse/jberet/it/scopes/stepscoped/StepScopedIT.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2015-2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package io.quarkiverse.jberet.it.scopes.stepscoped;
+
+import jakarta.batch.runtime.BatchStatus;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import io.quarkiverse.jberet.it.cdiscopes.AbstractQuarkusIT;
+import io.quarkus.test.junit.QuarkusTest;
+
+/**
+ * Tests for {@link org.jberet.cdi.StepScoped}.
+ */
+@QuarkusTest
+class StepScopedIT extends AbstractQuarkusIT {
+    static final String stepScopedTest = "stepScoped";
+    static final String stepScopedFailedTest = "stepScopedFail";
+    static final String stepScopedTest2 = "stepScoped2";
+    static final String stepScopedPartitionedTest = "stepScopedPartitioned";
+
+    @Test
+    void stepScopedTest() throws Exception {
+        final String stepName1Repeat3 = "stepScoped.step1TYPE stepScoped.step1TYPE stepScoped.step1TYPE stepScoped.step1METHOD stepScoped.step1METHOD stepScoped.step1METHOD stepScoped.step1FIELD stepScoped.step1FIELD stepScoped.step1FIELD";
+
+        final String stepName2 = "stepScoped.step2TYPE stepScoped.step2METHOD stepScoped.step2FIELD";
+
+        // same job, different steps, injected Foo should be different
+        // same step, different artifact, injected Foo (into both batchlet and step
+        // listener) should be the same
+
+        startJobAndWait(stepScopedTest);
+        Assertions.assertEquals(BatchStatus.COMPLETED, jobExecution.getBatchStatus());
+        Assertions.assertEquals(stepName1Repeat3, stepExecutions.get(0).getExitStatus());
+        Assertions.assertEquals(stepName2, stepExecutions.get(1).getExitStatus());
+
+        stepExecutions.clear();
+        jobExecution = null;
+        stepExecutions = null;
+
+        final String job2StepName1 = "stepScoped2.step1TYPE stepScoped2.step1METHOD stepScoped2.step1FIELD";
+        final String job2StepName2 = "stepScoped2.step2TYPE stepScoped2.step2METHOD stepScoped2.step2FIELD";
+
+        // run a different job (stepScoped2) to check that a different Foo instance is
+        // used within the scope of stepScoped2
+        startJobAndWait(stepScopedTest2);
+        Assertions.assertEquals(BatchStatus.COMPLETED, jobExecution.getBatchStatus());
+        Assertions.assertEquals(job2StepName1, stepExecutions.get(0).getExitStatus());
+        Assertions.assertEquals(job2StepName2, stepExecutions.get(1).getExitStatus());
+    }
+
+    @Test
+    void stepScopedPartitionedTest() throws Exception {
+        startJobAndWait(stepScopedPartitionedTest);
+        Assertions.assertEquals(BatchStatus.COMPLETED, jobExecution.getBatchStatus());
+
+        // step2 exit status is set in analyzer, to foo.stepNames.
+        final String stepExitStatus = stepExecution0.getExitStatus();
+
+        // beforeStep, afterStep, batchlet * 3 partitioins = 5
+        // and there are 3 injections: Foo, FooMethodTarget & FooFieldTarget
+        Assertions.assertEquals(
+                "stepScopedPartitioned.step1TYPE stepScopedPartitioned.step1TYPE stepScopedPartitioned.step1TYPE stepScopedPartitioned.step1TYPE stepScopedPartitioned.step1TYPE stepScopedPartitioned.step1METHOD stepScopedPartitioned.step1METHOD stepScopedPartitioned.step1METHOD stepScopedPartitioned.step1METHOD stepScopedPartitioned.step1METHOD stepScopedPartitioned.step1FIELD stepScopedPartitioned.step1FIELD stepScopedPartitioned.step1FIELD stepScopedPartitioned.step1FIELD stepScopedPartitioned.step1FIELD",
+                stepExitStatus);
+    }
+
+    @Test
+    public void stepScopedFail() throws Exception {
+        // injecting @StepScoped Foo into a job listener will fail
+        startJobAndWait(stepScopedFailedTest);
+        Assertions.assertEquals(BatchStatus.FAILED, jobExecution.getBatchStatus());
+    }
+
+}

--- a/integration-tests/scopes/step-scoped/src/test/java/io/quarkiverse/jberet/it/scopes/stepscoped/StepScopedListener.java
+++ b/integration-tests/scopes/step-scoped/src/test/java/io/quarkiverse/jberet/it/scopes/stepscoped/StepScopedListener.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2015-2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package io.quarkiverse.jberet.it.scopes.stepscoped;
+
+import jakarta.annotation.Priority;
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.inject.Alternative;
+import jakarta.enterprise.inject.Typed;
+import jakarta.inject.Named;
+
+@Named
+@Dependent
+@Alternative
+@Priority(1)
+@Typed(org.jberet.testapps.cdiscopes.stepscoped.StepScopedListener.class)
+public class StepScopedListener extends org.jberet.testapps.cdiscopes.stepscoped.StepScopedListener {
+}

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
     <quarkus.version>3.6.1</quarkus.version>
     <jakarta.batch-api.version>2.1.1</jakarta.batch-api.version>
-    <jberet.version>2.1.1.Final</jberet.version>
+    <jberet.version>2.2.0.Final</jberet.version>
     <jberet-rest.version>2.0.0.Final</jberet-rest.version>
     <jberet-schedule.version>2.0.0.Final</jberet-schedule.version>
     <jberet-jpa.version>2.1.4.Final</jberet-jpa.version>


### PR DESCRIPTION
- Fixes https://github.com/quarkiverse/quarkus-jberet/issues/122

Added job/step/partition scope management

I've added Quarkus specific implementation for batch scopes in runtime module and registered them in `JBeretProcessor`.
I marked PR as draft mainly because:

1. I'm not sure Quarkus specific implementations are implemented in the right way because they are reflection based
2. Tests are missing