### PR TITLE
Correct dead link in extension metadata

### DIFF
--- a/core/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/core/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -6,7 +6,7 @@ metadata:
   - "batch"
   - "jberet"
   - "jsr352"
-  guide: "https://quarkus.io/guides/jberet"
+  guide: "https://github.com/quarkiverse/quarkus-jberet#readme"
   categories:
   - "data"
   status: "preview"


### PR DESCRIPTION
We point to a guides page that doesn't exist, so I've updated to the best docs I could find.