### PR TITLE
Do not use Runtime configuration during deployment

### DIFF
--- a/core/deployment/src/main/java/io/quarkiverse/jberet/deployment/JBeretProcessor.java
+++ b/core/deployment/src/main/java/io/quarkiverse/jberet/deployment/JBeretProcessor.java
@@ -93,7 +93,6 @@ import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.RuntimeInitializedClassBuildItem;
 import io.quarkus.deployment.recording.RecorderContext;
-import io.quarkus.runtime.ThreadPoolConfig;
 import io.quarkus.runtime.configuration.ConfigurationException;
 
 public class JBeretProcessor {
@@ -261,7 +260,6 @@ public class JBeretProcessor {
     public void registerJobs(
             RecorderContext recorderContext,
             JBeretRecorder recorder,
-            JBeretConfig config,
             List<BatchJobBuildItem> batchJobs,
             BeanContainerBuildItem beanContainer) throws Exception {
         registerNonDefaultConstructors(recorderContext);
@@ -279,12 +277,10 @@ public class JBeretProcessor {
     @BuildStep
     @Record(ExecutionTime.RUNTIME_INIT)
     ServiceStartBuildItem init(JBeretRecorder recorder,
-            JBeretConfig config,
-            ThreadPoolConfig threadPoolConfig,
             BeanContainerBuildItem beanContainer) {
 
-        recorder.initJobOperator(config, threadPoolConfig, beanContainer.getValue());
-        recorder.initScheduler(config);
+        recorder.initJobOperator(beanContainer.getValue());
+        recorder.initScheduler();
 
         return new ServiceStartBuildItem("jberet");
     }


### PR DESCRIPTION
With https://github.com/quarkusio/quarkus/pull/48500, we will disallow the injection of Runtime configuration objects during deployment. The recommended way is to inject it directly into the Recorder, wrapped in a `RuntimeValue`.