### PR TITLE
Support both Quarkus REST and RESTEasy Classic in JBeret REST

### DIFF
--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -172,6 +172,32 @@ to your build file:
 implementation("io.quarkiverse.jberet:quarkus-jberet-rest:{project-version}")
 ----
 
+https://github.com/jberet/jberet-rest[JBeret REST] requires either
+https://quarkus.io/version/main/guides/rest[Quarkus REST] (recommended) or
+https://quarkus.io/version/main/guides/resteasy[Quarkus RESTEasy Classic]. If any of these are not yet available in
+the project, one must be added:
+
+[source,xml,role="primary asciidoc-tabs-target-sync-cli asciidoc-tabs-target-sync-maven"]
+.pom.xml
+----
+<dependency>
+  <groupId>io.quarkus</groupId>
+  <artifactId>quarkus-rest-jackson</artifactId>
+</dependency>
+
+<dependency>
+  <groupId>io.quarkus</groupId>
+  <artifactId>quarkus-rest-client-jackson</artifactId>
+</dependency>
+----
+
+[source,gradle,role="secondary asciidoc-tabs-target-sync-gradle"]
+.build.gradle
+----
+implementation("io.quarkus:quarkus-rest-jackson")
+implementation("io.quarkus:quarkus-rest-client-jackson")
+----
+
 The https://github.com/jberet/jberet-rest[JBeret REST] API, provides REST resources to several operations around the
 Batch API: starting and stopping jobs, querying the status of a job, schedule a job, and more. The extension
 includes a REST client to simplify the REST API calls:
@@ -201,7 +227,8 @@ downloads the World of Warcraft Auction House data and provides statistics about
 
 The Quakus JBeret Extension fully supports the Graal VM Native Image with the following exceptions:
 
-- https://jberet.gitbooks.io/jberet-user-guide/content/develop_batch_artifacts_in_script_languages/[Scripting Languages]. While `Javascript` should work, it is unlikely that other scripting languages will be supported in
+- https://jberet.gitbooks.io/jberet-user-guide/content/develop_batch_artifacts_in_script_languages/[Scripting Languages].
+While `Javascript` should work, it is unlikely that other scripting languages will be supported in
 https://github.com/oracle/graaljs/blob/master/docs/user/ScriptEngine.md[Graal] via JSR-223.
 
 [[extension-configuration-reference]]

--- a/integration-tests/chunk/pom.xml
+++ b/integration-tests/chunk/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>io.quarkiverse.jberet</groupId>
@@ -8,7 +9,21 @@
   </parent>
 
   <artifactId>quarkus-jberet-integration-tests-chunk</artifactId>
-
   <name>Quarkus - JBeret - Integrations Tests - Chunk</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.quarkiverse.jberet</groupId>
+      <artifactId>quarkus-jberet-rest</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-resteasy-jsonb</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-resteasy-client-jsonb</artifactId>
+    </dependency>
+  </dependencies>
 
 </project>

--- a/integration-tests/client/pom.xml
+++ b/integration-tests/client/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>io.quarkiverse.jberet</groupId>
@@ -8,7 +9,20 @@
   </parent>
 
   <artifactId>quarkus-jberet-integration-tests-client</artifactId>
-
   <name>Quarkus - JBeret - Integrations Tests - Client</name>
 
+  <dependencies>
+    <dependency>
+      <groupId>io.quarkiverse.jberet</groupId>
+      <artifactId>quarkus-jberet-rest</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-rest-jackson</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-rest-client-jackson</artifactId>
+    </dependency>
+  </dependencies>
 </project>

--- a/integration-tests/jdbc-repository/pom.xml
+++ b/integration-tests/jdbc-repository/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>io.quarkiverse.jberet</groupId>
@@ -8,13 +9,24 @@
   </parent>
 
   <artifactId>quarkus-jberet-integration-tests-jdbc-repository</artifactId>
-
   <name>Quarkus - JBeret - Integrations Tests - JDBC Repository</name>
 
   <dependencies>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-jdbc-h2-deployment</artifactId>
+      <artifactId>quarkus-jdbc-h2</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkiverse.jberet</groupId>
+      <artifactId>quarkus-jberet-rest</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-resteasy-jsonb</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-resteasy-client-jsonb</artifactId>
     </dependency>
 
     <dependency>

--- a/integration-tests/jpa-repository/pom.xml
+++ b/integration-tests/jpa-repository/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>io.quarkiverse.jberet</groupId>
@@ -8,7 +9,6 @@
   </parent>
 
   <artifactId>quarkus-jberet-integration-tests-jpa-repository</artifactId>
-
   <name>Quarkus - JBeret - Integrations Tests - JPA Repository</name>
 
   <dependencies>
@@ -16,10 +16,21 @@
       <groupId>io.quarkiverse.jberet</groupId>
       <artifactId>quarkus-jberet-jpa</artifactId>
     </dependency>
-
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-jdbc-h2</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkiverse.jberet</groupId>
+      <artifactId>quarkus-jberet-rest</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-resteasy-jsonb</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-resteasy-client-jsonb</artifactId>
     </dependency>
 
     <dependency>

--- a/integration-tests/mailer/pom.xml
+++ b/integration-tests/mailer/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>io.quarkiverse.jberet</groupId>
@@ -8,13 +9,24 @@
   </parent>
 
   <artifactId>quarkus-jberet-integration-tests-mailer</artifactId>
-
   <name>Quarkus - JBeret - Integrations Tests - Mailer</name>
 
   <dependencies>
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-mailer</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkiverse.jberet</groupId>
+      <artifactId>quarkus-jberet-rest</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-resteasy-jsonb</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-resteasy-client-jsonb</artifactId>
     </dependency>
   </dependencies>
 

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>io.quarkiverse.jberet</groupId>
@@ -16,10 +17,6 @@
     <dependency>
       <groupId>io.quarkiverse.jberet</groupId>
       <artifactId>quarkus-jberet</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>io.quarkiverse.jberet</groupId>
-      <artifactId>quarkus-jberet-rest</artifactId>
     </dependency>
 
     <dependency>
@@ -44,6 +41,7 @@
       <plugin>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-maven-plugin</artifactId>
+        <extensions>true</extensions>
         <executions>
           <execution>
             <goals>
@@ -115,5 +113,4 @@
       </properties>
     </profile>
   </profiles>
-
 </project>

--- a/integration-tests/programmatic/pom.xml
+++ b/integration-tests/programmatic/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>io.quarkiverse.jberet</groupId>
@@ -8,7 +9,21 @@
   </parent>
 
   <artifactId>quarkus-jberet-integration-tests-programmatic</artifactId>
-
   <name>Quarkus - JBeret - Integrations Tests - Programmatic</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.quarkiverse.jberet</groupId>
+      <artifactId>quarkus-jberet-rest</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-resteasy-jsonb</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-resteasy-client-jsonb</artifactId>
+    </dependency>
+  </dependencies>
 
 </project>

--- a/integration-tests/scheduler/pom.xml
+++ b/integration-tests/scheduler/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>io.quarkiverse.jberet</groupId>
@@ -8,7 +9,21 @@
   </parent>
 
   <artifactId>quarkus-jberet-integration-tests-scheduler</artifactId>
-
   <name>Quarkus - JBeret - Integrations Tests - Scheduler</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.quarkiverse.jberet</groupId>
+      <artifactId>quarkus-jberet-rest</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-resteasy-jsonb</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-resteasy-client-jsonb</artifactId>
+    </dependency>
+  </dependencies>
 
 </project>

--- a/integration-tests/scopes/common/pom.xml
+++ b/integration-tests/scopes/common/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>io.quarkiverse.jberet</groupId>

--- a/integration-tests/scopes/job-scoped/pom.xml
+++ b/integration-tests/scopes/job-scoped/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>io.quarkiverse.jberet</groupId>
@@ -18,7 +19,6 @@
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
-
     <dependency>
       <groupId>org.jberet.test-apps</groupId>
       <artifactId>jobScoped</artifactId>

--- a/integration-tests/scopes/partition-scoped/pom.xml
+++ b/integration-tests/scopes/partition-scoped/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>io.quarkiverse.jberet</groupId>
@@ -18,7 +19,6 @@
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
-
     <dependency>
       <groupId>org.jberet.test-apps</groupId>
       <artifactId>partitionScoped</artifactId>

--- a/integration-tests/scopes/step-scoped/pom.xml
+++ b/integration-tests/scopes/step-scoped/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>io.quarkiverse.jberet</groupId>
@@ -18,7 +19,6 @@
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
-
     <dependency>
       <groupId>org.jberet.test-apps</groupId>
       <artifactId>stepScoped</artifactId>

--- a/integration-tests/scripting/pom.xml
+++ b/integration-tests/scripting/pom.xml
@@ -1,31 +1,44 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
-    <parent>
-        <groupId>io.quarkiverse.jberet</groupId>
-        <artifactId>quarkus-jberet-integration-tests</artifactId>
-        <version>2.7.1-SNAPSHOT</version>
-    </parent>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>io.quarkiverse.jberet</groupId>
+    <artifactId>quarkus-jberet-integration-tests</artifactId>
+    <version>2.7.1-SNAPSHOT</version>
+  </parent>
 
-    <artifactId>quarkus-jberet-integration-tests-scripting</artifactId>
+  <artifactId>quarkus-jberet-integration-tests-scripting</artifactId>
+  <name>Quarkus - JBeret - Integrations Tests - Scripting</name>
 
-    <name>Quarkus - JBeret - Integrations Tests - Scripting</name>
+  <properties>
+    <version.groovy>3.0.25</version.groovy>
+  </properties>
 
-    <properties>
-        <version.groovy>3.0.25</version.groovy>
-    </properties>
+  <dependencies>
+    <dependency>
+      <groupId>io.quarkiverse.jberet</groupId>
+      <artifactId>quarkus-jberet-rest</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-rest-jackson</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-rest-client-jackson</artifactId>
+    </dependency>
 
-    <dependencies>
-        <dependency>
-            <groupId>org.codehaus.groovy</groupId>
-            <artifactId>groovy-jsr223</artifactId>
-            <version>${version.groovy}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.codehaus.groovy</groupId>
-            <artifactId>groovy</artifactId>
-            <version>${version.groovy}</version>
-        </dependency>
-    </dependencies>
+    <dependency>
+      <groupId>org.codehaus.groovy</groupId>
+      <artifactId>groovy-jsr223</artifactId>
+      <version>${version.groovy}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.codehaus.groovy</groupId>
+      <artifactId>groovy</artifactId>
+      <version>${version.groovy}</version>
+    </dependency>
+  </dependencies>
 
 </project>

--- a/integration-tests/tck/deployment/pom.xml
+++ b/integration-tests/tck/deployment/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>io.quarkiverse.jberet</groupId>
@@ -14,12 +15,6 @@
     <dependency>
       <groupId>io.quarkiverse.jberet</groupId>
       <artifactId>quarkus-jberet-deployment</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>io.quarkiverse.jberet</groupId>
-      <artifactId>quarkus-jberet-rest-deployment</artifactId>
-      <version>${project.version}</version>
     </dependency>
 
     <dependency>

--- a/integration-tests/tck/deployment/src/main/java/io/quarkiverse/jberet/it/tck/deployment/TCKProcessor.java
+++ b/integration-tests/tck/deployment/src/main/java/io/quarkiverse/jberet/it/tck/deployment/TCKProcessor.java
@@ -18,14 +18,10 @@ import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.deployment.builditem.IndexDependencyBuildItem;
-import io.quarkus.resteasy.common.spi.ResteasyJaxrsProviderBuildItem;
 
 public class TCKProcessor {
     @BuildStep
-    public void tck(
-            BuildProducer<IndexDependencyBuildItem> indexDependency,
-            BuildProducer<ResteasyJaxrsProviderBuildItem> providers) {
-
+    public void tck(BuildProducer<IndexDependencyBuildItem> indexDependency) {
         indexDependency.produce(new IndexDependencyBuildItem("jakarta.batch", "com.ibm.jbatch.tck"));
     }
 

--- a/integration-tests/tck/runner/pom.xml
+++ b/integration-tests/tck/runner/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>io.quarkiverse.jberet</groupId>

--- a/integration-tests/tck/runtime/pom.xml
+++ b/integration-tests/tck/runtime/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>io.quarkiverse.jberet</groupId>

--- a/rest/deployment/pom.xml
+++ b/rest/deployment/pom.xml
@@ -17,29 +17,19 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-deployment</artifactId>
+            <artifactId>quarkus-vertx-http-deployment</artifactId>
         </dependency>
+
         <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-jsonb-deployment</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-client-deployment</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-client-jsonb-deployment</artifactId>
+            <groupId>io.quarkiverse.jberet</groupId>
+            <artifactId>quarkus-jberet-rest</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-jackson-deployment</artifactId>
         </dependency>
-        <dependency>
-            <groupId>io.quarkiverse.jberet</groupId>
-            <artifactId>quarkus-jberet-rest</artifactId>
-        </dependency>
 
+        <!-- Test Dependencies -->
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit5-internal</artifactId>
@@ -48,6 +38,16 @@
         <dependency>
             <groupId>org.awaitility</groupId>
             <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest-jackson-deployment</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest-client-jackson-deployment</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/rest/deployment/src/main/java/io/quarkiverse/jberet/rest/deployment/JBeretRestProcessor.java
+++ b/rest/deployment/src/main/java/io/quarkiverse/jberet/rest/deployment/JBeretRestProcessor.java
@@ -1,30 +1,50 @@
 package io.quarkiverse.jberet.rest.deployment;
 
+import static io.quarkus.deployment.Capability.RESTEASY_JSON_JACKSON;
+import static io.quarkus.deployment.Capability.RESTEASY_JSON_JACKSON_CLIENT;
+import static io.quarkus.deployment.Capability.RESTEASY_JSON_JSONB;
+import static io.quarkus.deployment.Capability.RESTEASY_JSON_JSONB_CLIENT;
+import static io.quarkus.deployment.Capability.RESTEASY_REACTIVE_JSON_JACKSON;
+import static io.quarkus.deployment.Capability.RESTEASY_REACTIVE_JSON_JSONB;
+import static io.quarkus.deployment.Capability.REST_CLIENT_REACTIVE_JACKSON;
+import static io.quarkus.deployment.Capability.REST_CLIENT_REACTIVE_JSONB;
+
 import io.quarkiverse.jberet.rest.runtime.JBeretRestProducer;
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
+import io.quarkus.deployment.Capabilities;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
-import io.quarkus.deployment.builditem.CapabilityBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.IndexDependencyBuildItem;
-import io.quarkus.resteasy.common.spi.ResteasyJaxrsProviderBuildItem;
 
-public class JBeretRestProcessor {
+class JBeretRestProcessor {
     @BuildStep
-    public void registerExtension(BuildProducer<FeatureBuildItem> feature, BuildProducer<CapabilityBuildItem> capability) {
+    void registerExtension(Capabilities capabilities, BuildProducer<FeatureBuildItem> feature) {
+        boolean isRestClassicPresent = capabilities.isPresent(RESTEASY_JSON_JACKSON)
+                && capabilities.isPresent(RESTEASY_JSON_JACKSON_CLIENT) ||
+                capabilities.isPresent(RESTEASY_JSON_JSONB) && capabilities.isPresent(RESTEASY_JSON_JSONB_CLIENT);
+
+        boolean isRestReactivePresent = capabilities.isPresent(RESTEASY_REACTIVE_JSON_JACKSON)
+                && capabilities.isPresent(REST_CLIENT_REACTIVE_JACKSON) ||
+                capabilities.isPresent(RESTEASY_REACTIVE_JSON_JSONB) && capabilities.isPresent(REST_CLIENT_REACTIVE_JSONB);
+
+        if (!isRestClassicPresent && !isRestReactivePresent) {
+            throw new IllegalStateException("""
+                    JBeret REST Client requires a Quarkus REST Extension, but none could be found. \
+                    Please either add `quarkus-rest-jackson` and `quarkus-rest-client-jackson` (recommended), \
+                    or add `quarkus-resteasy-jackson` and `quarkus-resteasy-client-jackson` to the project dependencies.""");
+        }
+
         feature.produce(new FeatureBuildItem("jberet-rest"));
     }
 
     @BuildStep
-    public void additionalBeans(BuildProducer<AdditionalBeanBuildItem> additionalBeans) {
-        additionalBeans.produce(new AdditionalBeanBuildItem(JBeretRestProducer.class));
+    void indexJBeretRest(BuildProducer<IndexDependencyBuildItem> indexDependency) {
+        indexDependency.produce(new IndexDependencyBuildItem("org.jberet", "jberet-rest-api"));
     }
 
     @BuildStep
-    public void rest(
-            BuildProducer<IndexDependencyBuildItem> indexDependency,
-            BuildProducer<ResteasyJaxrsProviderBuildItem> providers) {
-
-        indexDependency.produce(new IndexDependencyBuildItem("org.jberet", "jberet-rest-api"));
+    void additionalBeans(BuildProducer<AdditionalBeanBuildItem> additionalBeans) {
+        additionalBeans.produce(new AdditionalBeanBuildItem(JBeretRestProducer.class));
     }
 }

--- a/rest/runtime/pom.xml
+++ b/rest/runtime/pom.xml
@@ -18,29 +18,23 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-jsonb</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-client</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-client-jsonb</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-jackson</artifactId>
+            <artifactId>quarkus-vertx-http</artifactId>
         </dependency>
 
         <dependency>
             <groupId>org.jberet</groupId>
             <artifactId>jberet-rest-api</artifactId>
         </dependency>
+        <dependency>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
+        </dependency>
+        <!-- JBeret REST Uses Jackson ObjectMapper internally -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jackson</artifactId>
+        </dependency>
+
         <dependency>
             <groupId>org.graalvm.sdk</groupId>
             <artifactId>graal-sdk</artifactId>


### PR DESCRIPTION
- Fixes #459 

Users must now explicitly declare the REST/REST Client and JSON extensions to use (it was defaulting to Resteasy Classic and JSON-B), which caused issues if the project required Resteasy Reactive or Jackson (or forced the project to use Classic and JSON-B).