### PR TITLE
Added job-launcher example application to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Example applications can be found inside the `integration-tests` folder:
 - `chunk` - A simple Job that reads, processes, and stores data from a file.
 - `jdbc-repository` - A Job that uses a `jdbc` datasource to store JBeret and Job metadata.
 - `scheduler` - Schedule a Job to run every 10 seconds
+- `job-launcher` - A `@QuarkusMain` application using `QuarkusJobLauncher` with start and restart
 
 Or take a look into the [World of Warcraft Auctions - Batch Application](https://github.com/radcortez/wow-auctions). It
 downloads the World of Warcraft Auction House data and provides statistics about items prices.


### PR DESCRIPTION
The user guide lists the job-launcher example application. The README does not. 

I thought it makes sense to align both.