### PR TITLE
Fix ScheduleExpression JSON serialization and cron expression generation

### DIFF
--- a/core/runtime/pom.xml
+++ b/core/runtime/pom.xml
@@ -66,6 +66,12 @@
             <artifactId>jakarta.ejb-api</artifactId>
             <version>4.0.1</version>
         </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/core/runtime/src/main/java/io/quarkiverse/jberet/runtime/QuarkusJobOperator.java
+++ b/core/runtime/src/main/java/io/quarkiverse/jberet/runtime/QuarkusJobOperator.java
@@ -48,7 +48,7 @@ public class QuarkusJobOperator extends AbstractJobOperator {
     @Override
     public long start(final String jobXMLName, final Properties jobParameters)
             throws JobStartException, JobSecurityException {
-        return start(jobXMLName, jobParameters, null);
+        return start(jobXMLName, jobParameters != null ? jobParameters : new Properties(), null);
     }
 
     @Override
@@ -68,7 +68,7 @@ public class QuarkusJobOperator extends AbstractJobOperator {
     public long restart(final long executionId, final Properties restartParameters)
             throws JobExecutionAlreadyCompleteException, NoSuchJobExecutionException, JobExecutionNotMostRecentException,
             JobRestartException, JobSecurityException {
-        return restart(executionId, restartParameters, null);
+        return restart(executionId, restartParameters != null ? restartParameters : new Properties(), null);
     }
 
     @Override

--- a/core/runtime/src/main/java/io/quarkiverse/jberet/runtime/QuarkusJobScheduler.java
+++ b/core/runtime/src/main/java/io/quarkiverse/jberet/runtime/QuarkusJobScheduler.java
@@ -138,14 +138,60 @@ public class QuarkusJobScheduler extends JobScheduler {
         return TRIGGER_ID_PREFIX + jobName + "-" + ids.getAndIncrement();
     }
 
-    private String toCronExpression(final ScheduleExpression scheduleExpression) {
+    static String toCronExpression(final ScheduleExpression scheduleExpression) {
+        String dayOfMonth = scheduleExpression.getDayOfMonth();
+        String dayOfWeek = toDayOfWeek(scheduleExpression.getDayOfWeek());
+
+        if (!"*".equals(dayOfWeek) && !"?".equals(dayOfWeek)) {
+            dayOfMonth = "?";
+        } else if (!"*".equals(dayOfMonth) && !"?".equals(dayOfMonth)) {
+            dayOfWeek = "?";
+        } else {
+            dayOfWeek = "?";
+        }
+
         return scheduleExpression.getSecond() + " " +
                 scheduleExpression.getMinute() + " " +
                 scheduleExpression.getHour() + " " +
-                scheduleExpression.getDayOfMonth() + " " +
+                dayOfMonth + " " +
                 scheduleExpression.getMonth() + " " +
-                scheduleExpression.getDayOfWeek() + " " +
+                dayOfWeek + " " +
                 scheduleExpression.getYear();
+    }
+
+    // EJB: 0=Sun, 1=Mon, ..., 6=Sat, 7=Sun
+    // Quartz: 1=Sun, 2=Mon, ..., 7=Sat
+    static String toDayOfWeek(String dayOfWeek) {
+        if (dayOfWeek == null || dayOfWeek.equals("*") || dayOfWeek.equals("?")) {
+            return dayOfWeek;
+        }
+
+        StringBuilder result = new StringBuilder();
+        for (String listPart : dayOfWeek.split(",")) {
+            if (!result.isEmpty()) {
+                result.append(",");
+            }
+            if (listPart.contains("/")) {
+                String[] parts = listPart.split("/", 2);
+                result.append(convertDayOfWeek(parts[0])).append("/").append(parts[1]);
+            } else if (listPart.contains("-")) {
+                String[] parts = listPart.split("-", 2);
+                result.append(convertDayOfWeek(parts[0])).append("-").append(convertDayOfWeek(parts[1]));
+            } else {
+                result.append(convertDayOfWeek(listPart));
+            }
+        }
+        return result.toString();
+    }
+
+    static String convertDayOfWeek(String token) {
+        try {
+            int value = Integer.parseInt(token.trim());
+            int convertedValue = (value == 0 || value == 7) ? 1 : value + 1;
+            return String.valueOf(convertedValue);
+        } catch (NumberFormatException e) {
+            return token;
+        }
     }
 
     public static class Delegate extends JobScheduler {

--- a/core/runtime/src/test/java/io/quarkiverse/jberet/runtime/QuarkusJobSchedulerTest.java
+++ b/core/runtime/src/test/java/io/quarkiverse/jberet/runtime/QuarkusJobSchedulerTest.java
@@ -1,0 +1,78 @@
+package io.quarkiverse.jberet.runtime;
+
+import static io.quarkiverse.jberet.runtime.QuarkusJobScheduler.toCronExpression;
+import static io.quarkiverse.jberet.runtime.QuarkusJobScheduler.toDayOfWeek;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import jakarta.ejb.ScheduleExpression;
+
+import org.junit.jupiter.api.Test;
+
+class QuarkusJobSchedulerTest {
+
+    @Test
+    void wildcards() {
+        assertEquals("*", toDayOfWeek("*"));
+        assertEquals("?", toDayOfWeek("?"));
+        assertNull(toDayOfWeek(null));
+    }
+
+    @Test
+    void singleNumericValues() {
+        assertEquals("1", toDayOfWeek("0"));
+        assertEquals("2", toDayOfWeek("1"));
+        assertEquals("3", toDayOfWeek("2"));
+        assertEquals("4", toDayOfWeek("3"));
+        assertEquals("5", toDayOfWeek("4"));
+        assertEquals("6", toDayOfWeek("5"));
+        assertEquals("7", toDayOfWeek("6"));
+        assertEquals("1", toDayOfWeek("7"));
+    }
+
+    @Test
+    void namedDays() {
+        assertEquals("MON", toDayOfWeek("MON"));
+        assertEquals("Mon", toDayOfWeek("Mon"));
+        assertEquals("FRI", toDayOfWeek("FRI"));
+    }
+
+    @Test
+    void ranges() {
+        assertEquals("2-6", toDayOfWeek("1-5"));
+        assertEquals("1-7", toDayOfWeek("0-6"));
+        assertEquals("Mon-Fri", toDayOfWeek("Mon-Fri"));
+    }
+
+    @Test
+    void lists() {
+        assertEquals("2,4,6", toDayOfWeek("1,3,5"));
+        assertEquals("MON,WED,FRI", toDayOfWeek("MON,WED,FRI"));
+    }
+
+    @Test
+    void increments() {
+        assertEquals("2/2", toDayOfWeek("1/2"));
+        assertEquals("1/3", toDayOfWeek("0/3"));
+    }
+
+    @Test
+    void cronExpressionDefaults() {
+        assertEquals("0 0 0 * * ? *", toCronExpression(new ScheduleExpression()));
+    }
+
+    @Test
+    void cronExpressionWithHour() {
+        assertEquals("0 0 6 * * ? *", toCronExpression(new ScheduleExpression().hour(6)));
+    }
+
+    @Test
+    void cronExpressionWithDayOfWeek() {
+        assertEquals("0 0 0 ? * 2 *", toCronExpression(new ScheduleExpression().dayOfWeek(1)));
+    }
+
+    @Test
+    void cronExpressionWithDayOfMonth() {
+        assertEquals("0 0 0 15 * ? *", toCronExpression(new ScheduleExpression().dayOfMonth(15)));
+    }
+}

--- a/rest/deployment/pom.xml
+++ b/rest/deployment/pom.xml
@@ -28,6 +28,11 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-jackson-deployment</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jsonb-deployment</artifactId>
+            <optional>true</optional>
+        </dependency>
 
         <!-- Test Dependencies -->
         <dependency>
@@ -41,6 +46,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-rest-jackson-deployment</artifactId>
             <scope>test</scope>
@@ -48,6 +58,16 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-rest-client-jackson-deployment</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest-jsonb-deployment</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest-client-jsonb-deployment</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/rest/deployment/src/main/java/io/quarkiverse/jberet/rest/deployment/JBeretRestProcessor.java
+++ b/rest/deployment/src/main/java/io/quarkiverse/jberet/rest/deployment/JBeretRestProcessor.java
@@ -10,8 +10,11 @@ import static io.quarkus.deployment.Capability.REST_CLIENT_REACTIVE_JACKSON;
 import static io.quarkus.deployment.Capability.REST_CLIENT_REACTIVE_JSONB;
 
 import io.quarkiverse.jberet.rest.runtime.JBeretRestProducer;
+import io.quarkiverse.jberet.rest.runtime.ScheduleExpressionJsonbConfigCustomizer;
+import io.quarkiverse.jberet.rest.runtime.ScheduleExpressionObjectMapperCustomizer;
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.deployment.Capabilities;
+import io.quarkus.deployment.Capability;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
@@ -44,7 +47,13 @@ class JBeretRestProcessor {
     }
 
     @BuildStep
-    void additionalBeans(BuildProducer<AdditionalBeanBuildItem> additionalBeans) {
+    void additionalBeans(Capabilities capabilities, BuildProducer<AdditionalBeanBuildItem> additionalBeans) {
         additionalBeans.produce(new AdditionalBeanBuildItem(JBeretRestProducer.class));
+        if (capabilities.isPresent(Capability.JACKSON)) {
+            additionalBeans.produce(new AdditionalBeanBuildItem(ScheduleExpressionObjectMapperCustomizer.class));
+        }
+        if (capabilities.isPresent(Capability.JSONB)) {
+            additionalBeans.produce(new AdditionalBeanBuildItem(ScheduleExpressionJsonbConfigCustomizer.class));
+        }
     }
 }

--- a/rest/deployment/src/test/java/io/quarkiverse/jberet/rest/deployment/ScheduleExpressionJacksonTest.java
+++ b/rest/deployment/src/test/java/io/quarkiverse/jberet/rest/deployment/ScheduleExpressionJacksonTest.java
@@ -1,0 +1,70 @@
+package io.quarkiverse.jberet.rest.deployment;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import jakarta.ejb.ScheduleExpression;
+import jakarta.inject.Inject;
+
+import org.jberet.schedule.JobScheduleConfig;
+import org.jberet.schedule.JobScheduleConfigBuilder;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.quarkus.test.QuarkusExtensionTest;
+
+public class ScheduleExpressionJacksonTest {
+    @RegisterExtension
+    static QuarkusExtensionTest TEST = new QuarkusExtensionTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class));
+
+    @Inject
+    ObjectMapper objectMapper;
+
+    @Test
+    void scheduleExpressionRoundTrip() throws Exception {
+        ScheduleExpression expression = new ScheduleExpression()
+                .hour("6")
+                .minute("30")
+                .second("0");
+
+        JobScheduleConfig config = JobScheduleConfigBuilder.newInstance()
+                .jobName("myJob")
+                .scheduleExpression(expression)
+                .build();
+
+        String json = objectMapper.writeValueAsString(config);
+
+        JobScheduleConfig deserialized = objectMapper.readValue(json, JobScheduleConfig.class);
+
+        assertNotNull(deserialized.getScheduleExpression(),
+                "scheduleExpression should not be null after JSON deserialization");
+        assertEquals("6", deserialized.getScheduleExpression().getHour(),
+                "hour should be preserved after JSON round-trip");
+        assertEquals("30", deserialized.getScheduleExpression().getMinute(),
+                "minute should be preserved after JSON round-trip");
+    }
+
+    @Test
+    void scheduleExpressionWithNumericValues() throws Exception {
+        String json = """
+                {
+                    "jobName": "myJob",
+                    "scheduleExpression": { "hour": 6, "minute": 30, "second": 0 }
+                }
+                """;
+
+        JobScheduleConfig deserialized = objectMapper.readValue(json, JobScheduleConfig.class);
+
+        assertNotNull(deserialized.getScheduleExpression(),
+                "scheduleExpression should not be null when using numeric values");
+        assertEquals("6", deserialized.getScheduleExpression().getHour(),
+                "numeric hour should be deserialized as string");
+        assertEquals("30", deserialized.getScheduleExpression().getMinute(),
+                "numeric minute should be deserialized as string");
+    }
+}

--- a/rest/deployment/src/test/java/io/quarkiverse/jberet/rest/deployment/ScheduleExpressionJsonbSerializationTest.java
+++ b/rest/deployment/src/test/java/io/quarkiverse/jberet/rest/deployment/ScheduleExpressionJsonbSerializationTest.java
@@ -1,0 +1,69 @@
+package io.quarkiverse.jberet.rest.deployment;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import jakarta.ejb.ScheduleExpression;
+import jakarta.inject.Inject;
+import jakarta.json.bind.Jsonb;
+
+import org.jberet.schedule.JobScheduleConfig;
+import org.jberet.schedule.JobScheduleConfigBuilder;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+
+public class ScheduleExpressionJsonbSerializationTest {
+    @RegisterExtension
+    static QuarkusExtensionTest TEST = new QuarkusExtensionTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class));
+
+    @Inject
+    Jsonb jsonb;
+
+    @Test
+    void scheduleExpressionRoundTrip() throws Exception {
+        ScheduleExpression expression = new ScheduleExpression()
+                .hour("6")
+                .minute("30")
+                .second("0");
+
+        JobScheduleConfig config = JobScheduleConfigBuilder.newInstance()
+                .jobName("myJob")
+                .scheduleExpression(expression)
+                .build();
+
+        String json = jsonb.toJson(config);
+
+        JobScheduleConfig deserialized = jsonb.fromJson(json, JobScheduleConfig.class);
+
+        assertNotNull(deserialized.getScheduleExpression(),
+                "scheduleExpression should not be null after JSON-B deserialization");
+        assertEquals("6", deserialized.getScheduleExpression().getHour(),
+                "hour should be preserved after JSON-B round-trip");
+        assertEquals("30", deserialized.getScheduleExpression().getMinute(),
+                "minute should be preserved after JSON-B round-trip");
+    }
+
+    @Test
+    void scheduleExpressionWithNumericValues() {
+        String json = """
+                {
+                    "jobName": "myJob",
+                    "scheduleExpression": { "hour": 6, "minute": 30, "second": 0 }
+                }
+                """;
+
+        JobScheduleConfig deserialized = jsonb.fromJson(json, JobScheduleConfig.class);
+
+        assertNotNull(deserialized.getScheduleExpression(),
+                "scheduleExpression should not be null when using numeric values");
+        assertEquals("6", deserialized.getScheduleExpression().getHour(),
+                "numeric hour should be deserialized as string");
+        assertEquals("30", deserialized.getScheduleExpression().getMinute(),
+                "numeric minute should be deserialized as string");
+    }
+}

--- a/rest/deployment/src/test/java/io/quarkiverse/jberet/rest/deployment/ScheduleExpressionRestTest.java
+++ b/rest/deployment/src/test/java/io/quarkiverse/jberet/rest/deployment/ScheduleExpressionRestTest.java
@@ -1,0 +1,100 @@
+package io.quarkiverse.jberet.rest.deployment;
+
+import static jakarta.ws.rs.core.HttpHeaders.ACCEPT;
+import static jakarta.ws.rs.core.HttpHeaders.CONTENT_TYPE;
+import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+
+import jakarta.batch.api.Batchlet;
+import jakarta.batch.runtime.BatchStatus;
+import jakarta.ejb.ScheduleExpression;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.Dependent;
+import jakarta.inject.Named;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.Response;
+
+import org.jberet.schedule.JobScheduleConfig;
+import org.jberet.schedule.JobScheduleConfigBuilder;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+import io.restassured.RestAssured;
+import io.restassured.filter.log.RequestLoggingFilter;
+import io.restassured.filter.log.ResponseLoggingFilter;
+import io.restassured.http.Header;
+
+class ScheduleExpressionRestTest {
+    @RegisterExtension
+    static QuarkusExtensionTest TEST = new QuarkusExtensionTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(ScheduleResource.class, ScheduleBatchlet.class)
+                    .addAsResource(new StringAsset("%test.quarkus.http.port=8081\n"), "application.properties")
+                    .addAsManifestResource("batchlet.xml", "batch-jobs/batchlet.xml"));
+
+    @BeforeAll
+    static void beforeAll() {
+        RestAssured.filters(
+                (requestSpec, responseSpec, ctx) -> {
+                    requestSpec.header(new Header(CONTENT_TYPE, APPLICATION_JSON));
+                    requestSpec.header(new Header(ACCEPT, APPLICATION_JSON));
+                    return ctx.next(requestSpec, responseSpec);
+                },
+                new RequestLoggingFilter(),
+                new ResponseLoggingFilter());
+    }
+
+    @Test
+    void deserializationThroughCustomEndpoint() {
+        JobScheduleConfig scheduleConfig = JobScheduleConfigBuilder.newInstance()
+                .scheduleExpression(new ScheduleExpression().hour(6))
+                .build();
+        RestAssured.given()
+                .body(scheduleConfig)
+                .post("/schedule")
+                .then()
+                .statusCode(200);
+    }
+
+    @Test
+    void scheduleExpressionViaJobsEndpoint() {
+        RestAssured.given()
+                .body("""
+                        { "scheduleExpression": { "hour": "6" } }
+                        """)
+                .post("/jobs/batchlet/schedule")
+                .then()
+                .statusCode(200)
+                .body("id", notNullValue())
+                .body("status", equalTo("SCHEDULED"));
+    }
+
+    @Named("batchlet")
+    @Dependent
+    public static class ScheduleBatchlet implements Batchlet {
+        @Override
+        public String process() {
+            return BatchStatus.COMPLETED.toString();
+        }
+
+        @Override
+        public void stop() {
+        }
+    }
+
+    @ApplicationScoped
+    @Path("/schedule")
+    static class ScheduleResource {
+        @POST
+        public Response schedule(JobScheduleConfig scheduleConfig) {
+            return Response.ok().build();
+        }
+    }
+}

--- a/rest/runtime/pom.xml
+++ b/rest/runtime/pom.xml
@@ -34,6 +34,11 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-jackson</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jsonb</artifactId>
+            <optional>true</optional>
+        </dependency>
 
         <dependency>
             <groupId>org.graalvm.sdk</groupId>

--- a/rest/runtime/src/main/java/io/quarkiverse/jberet/rest/runtime/ScheduleExpressionJsonbConfigCustomizer.java
+++ b/rest/runtime/src/main/java/io/quarkiverse/jberet/rest/runtime/ScheduleExpressionJsonbConfigCustomizer.java
@@ -1,0 +1,156 @@
+package io.quarkiverse.jberet.rest.runtime;
+
+import java.lang.reflect.Type;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.Date;
+import java.util.Properties;
+import java.util.function.Consumer;
+
+import jakarta.ejb.ScheduleExpression;
+import jakarta.inject.Singleton;
+import jakarta.json.JsonNumber;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonString;
+import jakarta.json.JsonValue;
+import jakarta.json.bind.JsonbConfig;
+import jakarta.json.bind.serializer.DeserializationContext;
+import jakarta.json.bind.serializer.JsonbDeserializer;
+import jakarta.json.bind.serializer.JsonbSerializer;
+import jakarta.json.bind.serializer.SerializationContext;
+import jakarta.json.stream.JsonGenerator;
+import jakarta.json.stream.JsonParser;
+
+import org.jberet.schedule.JobScheduleConfig;
+import org.jberet.schedule.JobScheduleConfigBuilder;
+
+import io.quarkus.jsonb.JsonbConfigCustomizer;
+
+@Singleton
+public class ScheduleExpressionJsonbConfigCustomizer implements JsonbConfigCustomizer {
+    static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter
+            .ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSX")
+            .withZone(ZoneId.systemDefault());
+
+    @Override
+    public void customize(JsonbConfig config) {
+        config.withSerializers(new ScheduleExpressionSerializer());
+        config.withDeserializers(new JobScheduleConfigDeserializer());
+    }
+
+    static class ScheduleExpressionSerializer implements JsonbSerializer<ScheduleExpression> {
+        @Override
+        public void serialize(ScheduleExpression value, JsonGenerator gen, SerializationContext ctx) {
+            gen.writeStartObject();
+            writeIfNotNull(gen, "second", value.getSecond());
+            writeIfNotNull(gen, "minute", value.getMinute());
+            writeIfNotNull(gen, "hour", value.getHour());
+            writeIfNotNull(gen, "dayOfMonth", value.getDayOfMonth());
+            writeIfNotNull(gen, "dayOfWeek", value.getDayOfWeek());
+            writeIfNotNull(gen, "month", value.getMonth());
+            writeIfNotNull(gen, "year", value.getYear());
+            writeIfNotNull(gen, "timezone", value.getTimezone());
+            if (value.getStart() != null) {
+                gen.write("start", DATE_FORMATTER.format(value.getStart().toInstant()));
+            }
+            if (value.getEnd() != null) {
+                gen.write("end", DATE_FORMATTER.format(value.getEnd().toInstant()));
+            }
+            gen.writeEnd();
+        }
+
+        private void writeIfNotNull(JsonGenerator gen, String key, String value) {
+            if (value != null) {
+                gen.write(key, value);
+            }
+        }
+    }
+
+    static class JobScheduleConfigDeserializer implements JsonbDeserializer<JobScheduleConfig> {
+        @Override
+        public JobScheduleConfig deserialize(JsonParser parser, DeserializationContext ctx, Type rtType) {
+            JsonObject json = parser.getObject();
+            JobScheduleConfigBuilder builder = JobScheduleConfigBuilder.newInstance();
+
+            if (json.containsKey("jobName") && !json.isNull("jobName")) {
+                builder.jobName(json.getString("jobName"));
+            }
+            if (json.containsKey("jobExecutionId")) {
+                builder.jobExecutionId(getLong(json, "jobExecutionId"));
+            }
+            if (json.containsKey("jobParameters") && !json.isNull("jobParameters")) {
+                Properties props = new Properties();
+                JsonObject paramsObj = json.getJsonObject("jobParameters");
+                for (String key : paramsObj.keySet()) {
+                    props.setProperty(key, getAsString(paramsObj.get(key)));
+                }
+                builder.jobParameters(props);
+            }
+            if (json.containsKey("scheduleExpression") && !json.isNull("scheduleExpression")) {
+                builder.scheduleExpression(deserializeScheduleExpression(json.getJsonObject("scheduleExpression")));
+            }
+            if (json.containsKey("initialDelay")) {
+                builder.initialDelay(getLong(json, "initialDelay"));
+            }
+            if (json.containsKey("afterDelay")) {
+                builder.afterDelay(getLong(json, "afterDelay"));
+            }
+            if (json.containsKey("interval")) {
+                builder.interval(getLong(json, "interval"));
+            }
+            if (json.containsKey("persistent")) {
+                builder.persistent(json.getBoolean("persistent"));
+            }
+
+            return builder.build();
+        }
+
+        private ScheduleExpression deserializeScheduleExpression(JsonObject json) {
+            ScheduleExpression expression = new ScheduleExpression();
+
+            setIfPresent(json, "second", expression::second);
+            setIfPresent(json, "minute", expression::minute);
+            setIfPresent(json, "hour", expression::hour);
+            setIfPresent(json, "dayOfMonth", expression::dayOfMonth);
+            setIfPresent(json, "dayOfWeek", expression::dayOfWeek);
+            setIfPresent(json, "month", expression::month);
+            setIfPresent(json, "year", expression::year);
+            setIfPresent(json, "timezone", expression::timezone);
+            if (json.containsKey("start") && !json.isNull("start")) {
+                expression.start(Date.from(Instant.from(DATE_FORMATTER.parse(getAsString(json.get("start"))))));
+            }
+            if (json.containsKey("end") && !json.isNull("end")) {
+                expression.end(Date.from(Instant.from(DATE_FORMATTER.parse(getAsString(json.get("end"))))));
+            }
+
+            return expression;
+        }
+
+        private void setIfPresent(JsonObject json, String key, Consumer<String> setter) {
+            if (json.containsKey(key) && !json.isNull(key)) {
+                setter.accept(getAsString(json.get(key)));
+            }
+        }
+
+        private String getAsString(JsonValue value) {
+            if (value.getValueType() == JsonValue.ValueType.STRING) {
+                return ((JsonString) value).getString();
+            } else if (value.getValueType() == JsonValue.ValueType.NUMBER) {
+                return value.toString();
+            }
+            return value.toString();
+        }
+
+        private long getLong(JsonObject json, String key) {
+            JsonValue value = json.get(key);
+            if (value == null) {
+                return 0;
+            }
+            if (value.getValueType() == JsonValue.ValueType.NUMBER) {
+                return ((JsonNumber) value).longValue();
+            }
+            return Long.parseLong(value.toString());
+        }
+    }
+}

--- a/rest/runtime/src/main/java/io/quarkiverse/jberet/rest/runtime/ScheduleExpressionObjectMapperCustomizer.java
+++ b/rest/runtime/src/main/java/io/quarkiverse/jberet/rest/runtime/ScheduleExpressionObjectMapperCustomizer.java
@@ -1,0 +1,138 @@
+package io.quarkiverse.jberet.rest.runtime;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.Date;
+import java.util.Map;
+import java.util.Properties;
+
+import jakarta.ejb.ScheduleExpression;
+import jakarta.inject.Singleton;
+
+import org.jberet.schedule.JobScheduleConfig;
+import org.jberet.schedule.JobScheduleConfigBuilder;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import io.quarkus.jackson.ObjectMapperCustomizer;
+
+@Singleton
+public class ScheduleExpressionObjectMapperCustomizer implements ObjectMapperCustomizer {
+    static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter
+            .ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSX")
+            .withZone(ZoneId.systemDefault());
+
+    @Override
+    public void customize(ObjectMapper objectMapper) {
+        SimpleModule module = new SimpleModule("ScheduleExpressionModule");
+        module.addSerializer(ScheduleExpression.class, new ScheduleExpressionSerializer());
+        module.addDeserializer(JobScheduleConfig.class, new JobScheduleConfigDeserializer());
+        objectMapper.registerModule(module);
+    }
+
+    static class ScheduleExpressionSerializer extends JsonSerializer<ScheduleExpression> {
+        @Override
+        public void serialize(ScheduleExpression value, JsonGenerator gen, SerializerProvider serializers)
+                throws IOException {
+            gen.writeStartObject();
+            writeIfNotNull(gen, "second", value.getSecond());
+            writeIfNotNull(gen, "minute", value.getMinute());
+            writeIfNotNull(gen, "hour", value.getHour());
+            writeIfNotNull(gen, "dayOfMonth", value.getDayOfMonth());
+            writeIfNotNull(gen, "dayOfWeek", value.getDayOfWeek());
+            writeIfNotNull(gen, "month", value.getMonth());
+            writeIfNotNull(gen, "year", value.getYear());
+            writeIfNotNull(gen, "timezone", value.getTimezone());
+            if (value.getStart() != null) {
+                gen.writeStringField("start", DATE_FORMATTER.format(value.getStart().toInstant()));
+            }
+            if (value.getEnd() != null) {
+                gen.writeStringField("end", DATE_FORMATTER.format(value.getEnd().toInstant()));
+            }
+            gen.writeEndObject();
+        }
+
+        private void writeIfNotNull(JsonGenerator gen, String key, String value) throws IOException {
+            if (value != null) {
+                gen.writeStringField(key, value);
+            }
+        }
+    }
+
+    static class JobScheduleConfigDeserializer extends JsonDeserializer<JobScheduleConfig> {
+        @Override
+        public JobScheduleConfig deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+            ObjectNode node = p.getCodec().readTree(p);
+            JobScheduleConfigBuilder builder = JobScheduleConfigBuilder.newInstance();
+
+            if (node.has("jobName") && !node.get("jobName").isNull()) {
+                builder.jobName(node.get("jobName").asText());
+            }
+            if (node.has("jobExecutionId")) {
+                builder.jobExecutionId(node.get("jobExecutionId").asLong());
+            }
+            if (node.has("jobParameters") && !node.get("jobParameters").isNull()) {
+                Properties props = new Properties();
+                for (Map.Entry<String, JsonNode> field : node.get("jobParameters").properties()) {
+                    props.setProperty(field.getKey(), field.getValue().asText());
+                }
+                builder.jobParameters(props);
+            }
+            if (node.has("scheduleExpression") && !node.get("scheduleExpression").isNull()) {
+                builder.scheduleExpression(deserializeScheduleExpression(node.get("scheduleExpression")));
+            }
+            if (node.has("initialDelay")) {
+                builder.initialDelay(node.get("initialDelay").asLong());
+            }
+            if (node.has("afterDelay")) {
+                builder.afterDelay(node.get("afterDelay").asLong());
+            }
+            if (node.has("interval")) {
+                builder.interval(node.get("interval").asLong());
+            }
+            if (node.has("persistent")) {
+                builder.persistent(node.get("persistent").asBoolean());
+            }
+
+            return builder.build();
+        }
+
+        private ScheduleExpression deserializeScheduleExpression(JsonNode node) {
+            ScheduleExpression expression = new ScheduleExpression();
+
+            setIfPresent(node, "second", expression::second);
+            setIfPresent(node, "minute", expression::minute);
+            setIfPresent(node, "hour", expression::hour);
+            setIfPresent(node, "dayOfMonth", expression::dayOfMonth);
+            setIfPresent(node, "dayOfWeek", expression::dayOfWeek);
+            setIfPresent(node, "month", expression::month);
+            setIfPresent(node, "year", expression::year);
+            setIfPresent(node, "timezone", expression::timezone);
+            if (node.has("start") && !node.get("start").isNull()) {
+                expression.start(Date.from(Instant.from(DATE_FORMATTER.parse(node.get("start").asText()))));
+            }
+            if (node.has("end") && !node.get("end").isNull()) {
+                expression.end(Date.from(Instant.from(DATE_FORMATTER.parse(node.get("end").asText()))));
+            }
+
+            return expression;
+        }
+
+        private void setIfPresent(JsonNode node, String key, java.util.function.Consumer<String> setter) {
+            if (node.has(key) && !node.get(key).isNull()) {
+                setter.accept(node.get(key).asText());
+            }
+        }
+    }
+}


### PR DESCRIPTION
Register custom Jackson and JSON-B serializers for `ScheduleExpression` so that the JBeret REST API `/jobs/{jobName}/schedule` endpoint can properly deserialize scheduleExpression from JSON. The existing `@XmlJavaTypeAdapter` only worked for JAXB/XML and was silently ignored by Jackson and JSON-B.

Also, fix toCronExpression to produce valid Quartz cron expressions by replacing one of dayOfMonth/dayOfWeek with '?' when both are wildcards, and converting EJB day-of-week numbering (0=Sun) to Quartz (1=Sun)

- Fixes #536