### PR TITLE
List of all JBeret REST API endpoints to documentation

### DIFF
--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -228,6 +228,35 @@ void start() throws Exception {
 }
 ----
 
+The full list of all API endpoints:
+
+[cols="1,5"]
+|===
+|GET     |/jobexecutions
+|GET     |/jobexecutions/running
+|GET     |/jobexecutions/{jobExecutionId : \d+}
+|POST    |/jobexecutions/{jobExecutionId}/abandon
+|POST    |/jobexecutions/{jobExecutionId}/restart
+|POST    |/jobexecutions/{jobExecutionId}/resubmit
+|POST    |/jobexecutions/{jobExecutionId}/schedule
+|GET     |/jobexecutions/{jobExecutionId}/stepexecutions
+|GET     |/jobexecutions/{jobExecutionId}/stepexecutions/{stepExecutionId}
+|POST    |/jobexecutions/{jobExecutionId}/stop
+|GET     |/jobinstances
+|GET     |/jobinstances/count
+|GET     |/jobs
+|POST    |/jobs/submit
+|POST    |/jobs/{jobXmlName}/restart
+|POST    |/jobs/{jobXmlName}/schedule
+|POST    |/jobs/{jobXmlName}/start
+|GET     |/schedules
+|GET     |/schedules/features
+|GET     |/schedules/timezones
+|GET     |/schedules/{scheduleId : .*\d+.*}
+|DELETE  |/schedules/{scheduleId}
+|POST    |/schedules/{scheduleId}/cancel
+|===
+
 == Example Applications
 
 Example applications can be found inside the `integration-tests` folder:


### PR DESCRIPTION
Not much. Just a list of all API endpoints. Of course, one can always use the dev UI, but I think it's helpful to have a quick list in that spot.

Do you think it makes sense to add full API documentation? I can't find one online.